### PR TITLE
feat: localstorage based auth

### DIFF
--- a/apps/platform/app/(auth)/forgot-password/layout.tsx
+++ b/apps/platform/app/(auth)/forgot-password/layout.tsx
@@ -1,14 +1,13 @@
-import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
+import AuthRouteGuard from '@components/auth/auth-route-guard'
 
-export default async function Layout({
+export default function Layout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const cookieStore = await cookies()
-  if (cookieStore.has('access_token')) {
-    redirect('/')
-  }
-  return <>{children}</>
+  return (
+    <AuthRouteGuard requireAuth={false} redirectTo="/">
+      {children}
+    </AuthRouteGuard>
+  )
 }

--- a/apps/platform/app/(auth)/login/layout.tsx
+++ b/apps/platform/app/(auth)/login/layout.tsx
@@ -1,14 +1,13 @@
-import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
+import AuthRouteGuard from '@components/auth/auth-route-guard'
 
-export default async function Layout({
+export default function Layout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const cookieStore = await cookies()
-  if (cookieStore.has('access_token')) {
-    redirect('/')
-  }
-  return <>{children}</>
+  return (
+    <AuthRouteGuard requireAuth={false} redirectTo="/">
+      {children}
+    </AuthRouteGuard>
+  )
 }

--- a/apps/platform/app/(auth)/login/page.tsx
+++ b/apps/platform/app/(auth)/login/page.tsx
@@ -16,13 +16,14 @@ import { resendOTP } from '@lib/api/auth/otp-verify'
 import { globalAtom } from '@lib/atoms/global'
 import { useAtom } from 'jotai'
 import { useToast } from '@dalla/design-system/ui/toast/use-toast'
-import { redirect, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { useState, useEffect, useMemo } from 'react'
 import { Lock, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { GoogleIcon, LinkedInIcon } from '@lib/constants/social-media-icons'
 import { useSSO } from '@lib/hooks/use-sso'
 import { useTranslation } from '@hooks/use-translation'
 import { useLocale } from '@hooks/use-locale'
+import { setStoredAuthTokens } from '@lib/auth/token-storage'
 
 type FormData = z.infer<ReturnType<typeof createLoginSchema>>
 
@@ -95,10 +96,6 @@ export default function LoginPage() {
     }
   }, [searchParams, toast, t])
 
-  if (global.id) {
-    return redirect('/')
-  }
-
   const onSubmit = async (data: FormData) => {
     setIsSubmitting(true)
     try {
@@ -114,6 +111,7 @@ export default function LoginPage() {
         userType: mode === 'company' ? 'company' : 'user',
       })
       if (res.success) {
+        setStoredAuthTokens(res.data)
         window.location.href = '/'
       }
     } catch (e) {

--- a/apps/platform/app/(auth)/onboard/layout.tsx
+++ b/apps/platform/app/(auth)/onboard/layout.tsx
@@ -1,15 +1,13 @@
-import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
+import AuthRouteGuard from '@components/auth/auth-route-guard'
 
-export default async function Layout({
+export default function Layout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const cookieStore = await cookies()
-  if (!cookieStore.has('access_token')) {
-    redirect('/login')
-  }
-
-  return <>{children}</>
+  return (
+    <AuthRouteGuard requireAuth redirectTo="/login">
+      {children}
+    </AuthRouteGuard>
+  )
 }

--- a/apps/platform/app/(auth)/reset-password/layout.tsx
+++ b/apps/platform/app/(auth)/reset-password/layout.tsx
@@ -1,14 +1,13 @@
-import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
+import AuthRouteGuard from '@components/auth/auth-route-guard'
 
-export default async function Layout({
+export default function Layout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const cookieStore = await cookies()
-  if (cookieStore.has('access_token')) {
-    redirect('/')
-  }
-  return <>{children}</>
+  return (
+    <AuthRouteGuard requireAuth={false} redirectTo="/">
+      {children}
+    </AuthRouteGuard>
+  )
 }

--- a/apps/platform/app/(auth)/signup/layout.tsx
+++ b/apps/platform/app/(auth)/signup/layout.tsx
@@ -1,14 +1,13 @@
-import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
+import AuthRouteGuard from '@components/auth/auth-route-guard'
 
-export default async function Layout({
+export default function Layout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const cookieStore = await cookies()
-  if (cookieStore.has('access_token')) {
-    redirect('/')
-  }
-  return <>{children}</>
+  return (
+    <AuthRouteGuard requireAuth={false} redirectTo="/">
+      {children}
+    </AuthRouteGuard>
+  )
 }

--- a/apps/platform/app/(auth)/signup/page.tsx
+++ b/apps/platform/app/(auth)/signup/page.tsx
@@ -15,7 +15,6 @@ import { useQueryState } from 'nuqs'
 import { useToast } from '@dalla/design-system/ui/toast/use-toast'
 import { useAtom } from 'jotai'
 import { globalAtom } from '@lib/atoms/global'
-import { redirect } from 'next/navigation'
 import { useState, useMemo } from 'react'
 import { Lock, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { LinkedInIcon } from '@lib/constants/social-media-icons'
@@ -46,10 +45,6 @@ export default function SignupPage() {
   const { locale } = useLocale()
   const [global, setGlobal] = useAtom(globalAtom)
   const [showPassword, setShowPassword] = useState(false)
-
-  if (global.id) {
-    return redirect('/')
-  }
   const [mode, setMode] = useQueryState('mode', {
     defaultValue: 'company',
   })

--- a/apps/platform/app/(auth)/verify/layout.tsx
+++ b/apps/platform/app/(auth)/verify/layout.tsx
@@ -1,14 +1,13 @@
-import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
+import AuthRouteGuard from '@components/auth/auth-route-guard'
 
-export default async function Layout({
+export default function Layout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const cookieStore = await cookies()
-  if (cookieStore.has('access_token')) {
-    redirect('/')
-  }
-  return <>{children}</>
+  return (
+    <AuthRouteGuard requireAuth={false} redirectTo="/">
+      {children}
+    </AuthRouteGuard>
+  )
 }

--- a/apps/platform/app/(auth)/verify/page.tsx
+++ b/apps/platform/app/(auth)/verify/page.tsx
@@ -11,6 +11,7 @@ import { useToast } from '@dalla/design-system/ui/toast/use-toast'
 import { globalAtom } from '@lib/atoms/global'
 import { useAtom } from 'jotai'
 import { useTranslation } from '@hooks/use-translation'
+import { setStoredAuthTokens } from '@lib/auth/token-storage'
 
 export default function VerifyPage() {
   const t = useTranslation()
@@ -51,6 +52,7 @@ export default function VerifyPage() {
       })
 
       if (res.success) {
+        setStoredAuthTokens(res.data)
         router.push('/onboard')
       } else {
         toast({

--- a/apps/platform/app/(authed)/layout.client.tsx
+++ b/apps/platform/app/(authed)/layout.client.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'react'
 import { globalAtom } from '@lib/atoms/global'
 import { getDbReadyPromise } from '@lib/atoms/atom-with-localforge'
 import { DallaLoading } from '@components/shared/dalla-loading'
+import { clearStoredAuthTokens } from '@lib/auth/token-storage'
 
 export default function AuthedLayoutClient({
   children,
@@ -97,6 +98,16 @@ export default function AuthedLayoutClient({
 
     if (isError) {
       console.error('Profile fetch error:', error)
+      const statusCode =
+        typeof error === 'object' && error && 'status' in error
+          ? Number(error.status)
+          : undefined
+
+      if (statusCode === 401 || statusCode === 403) {
+        clearStoredAuthTokens()
+        router.push('/login')
+      }
+
       setIsLoading(false)
       return
     }

--- a/apps/platform/app/(authed)/layout.tsx
+++ b/apps/platform/app/(authed)/layout.tsx
@@ -1,18 +1,14 @@
-import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
 import AuthedLayoutClient from './layout.client'
+import AuthRouteGuard from '@components/auth/auth-route-guard'
 
-export const dynamic = 'force-dynamic'
-
-export default async function Layout({
+export default function Layout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const cookieStore = await cookies()
-  if (!cookieStore.has('access_token')) {
-    redirect('/login')
-  }
-
-  return <AuthedLayoutClient>{children}</AuthedLayoutClient>
+  return (
+    <AuthRouteGuard requireAuth redirectTo="/login">
+      <AuthedLayoutClient>{children}</AuthedLayoutClient>
+    </AuthRouteGuard>
+  )
 }

--- a/apps/platform/components/auth/auth-route-guard.tsx
+++ b/apps/platform/components/auth/auth-route-guard.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { ReactNode, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { DallaLoading } from '@components/shared/dalla-loading'
+import {
+  AUTH_TOKENS_CHANGED_EVENT,
+  hasStoredAccessToken,
+} from '@lib/auth/token-storage'
+
+interface AuthRouteGuardProps {
+  children: ReactNode
+  redirectTo: string
+  requireAuth: boolean
+}
+
+export default function AuthRouteGuard({
+  children,
+  redirectTo,
+  requireAuth,
+}: AuthRouteGuardProps) {
+  const router = useRouter()
+  const [isReady, setIsReady] = useState(false)
+  const [isAllowed, setIsAllowed] = useState(false)
+
+  useEffect(() => {
+    const syncAuthState = () => {
+      const hasToken = hasStoredAccessToken()
+      const allowed = requireAuth ? hasToken : !hasToken
+
+      setIsAllowed(allowed)
+      setIsReady(true)
+
+      if (!allowed) {
+        router.replace(redirectTo)
+      }
+    }
+
+    syncAuthState()
+
+    window.addEventListener('storage', syncAuthState)
+    window.addEventListener(
+      AUTH_TOKENS_CHANGED_EVENT,
+      syncAuthState as EventListener,
+    )
+
+    return () => {
+      window.removeEventListener('storage', syncAuthState)
+      window.removeEventListener(
+        AUTH_TOKENS_CHANGED_EVENT,
+        syncAuthState as EventListener,
+      )
+    }
+  }, [redirectTo, requireAuth, router])
+
+  if (!isReady) {
+    return requireAuth ? <DallaLoading /> : null
+  }
+
+  if (!isAllowed) {
+    return requireAuth ? <DallaLoading /> : null
+  }
+
+  return <>{children}</>
+}

--- a/apps/platform/components/auth/auth-route-guard.tsx
+++ b/apps/platform/components/auth/auth-route-guard.tsx
@@ -36,16 +36,24 @@ export default function AuthRouteGuard({
       }
     }
 
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.storageArea !== localStorage) {
+        return
+      }
+
+      syncAuthState()
+    }
+
     syncAuthState()
 
-    window.addEventListener('storage', syncAuthState)
+    window.addEventListener('storage', handleStorageChange)
     window.addEventListener(
       AUTH_TOKENS_CHANGED_EVENT,
       syncAuthState as EventListener,
     )
 
     return () => {
-      window.removeEventListener('storage', syncAuthState)
+      window.removeEventListener('storage', handleStorageChange)
       window.removeEventListener(
         AUTH_TOKENS_CHANGED_EVENT,
         syncAuthState as EventListener,

--- a/apps/platform/lib/api/auth/login.ts
+++ b/apps/platform/lib/api/auth/login.ts
@@ -6,16 +6,17 @@ interface Payload {
   userType: 'company' | 'user'
 }
 
+interface AuthPayload {
+  access_token: string
+  refresh_token: string
+}
+
 export async function login(payload: Payload) {
   let res = await axiosInstance
     .post<{
       success: boolean
       message: string
-      data: {
-        id: string
-        access_token: string
-        refresh_token: string
-      }
+      data: AuthPayload
     }>('/auth/login', payload)
     .then((res) => {
       return {
@@ -39,11 +40,7 @@ export async function loginWithGoogle(payload: {
     .post<{
       success: boolean
       message: string
-      data: {
-        id: string
-        access_token: string
-        refresh_token: string
-      }
+      data: AuthPayload
     }>('/auth/google', payload)
     .then((res) => {
       return {
@@ -68,11 +65,7 @@ export async function loginWithLinkedIn(payload: {
     .post<{
       success: boolean
       message: string
-      data: {
-        id: string
-        access_token: string
-        refresh_token: string
-      }
+      data: AuthPayload
     }>('/auth/linkedin', payload)
     .then((res) => {
       return {

--- a/apps/platform/lib/api/auth/logout.ts
+++ b/apps/platform/lib/api/auth/logout.ts
@@ -1,9 +1,9 @@
-import { axiosInstance } from '../instance'
 import localForage from 'localforage'
+import { clearStoredAuthTokens } from '@lib/auth/token-storage'
 
 export async function logout(queryClient?: any) {
   try {
-    const res = await axiosInstance.post('/auth/logout')
+    clearStoredAuthTokens()
 
     await localForage.clear()
 
@@ -12,11 +12,12 @@ export async function logout(queryClient?: any) {
       queryClient.clear()
     }
 
-    return res
+    return { success: true }
   } catch (err) {
     console.error('Logout error:', err)
 
     try {
+      clearStoredAuthTokens()
       await localForage.clear()
       if (queryClient) {
         queryClient.clear()

--- a/apps/platform/lib/api/auth/logout.ts
+++ b/apps/platform/lib/api/auth/logout.ts
@@ -3,6 +3,14 @@ import { clearStoredAuthTokens } from '@lib/auth/token-storage'
 
 export async function logout(queryClient?: any) {
   try {
+    try {
+      await fetch('/auth/logout', {
+        method: 'POST',
+        credentials: 'include',
+      })
+    } catch (logoutRequestError) {
+      console.error('Backend logout failed:', logoutRequestError)
+    }
     clearStoredAuthTokens()
 
     await localForage.clear()

--- a/apps/platform/lib/api/auth/otp-verify.ts
+++ b/apps/platform/lib/api/auth/otp-verify.ts
@@ -11,6 +11,10 @@ export async function verify(payload: Payload) {
     .post<{
       success: boolean
       message: string
+      data: {
+        access_token: string
+        refresh_token: string
+      }
     }>('/auth/verify', payload)
     .then((res) => {
       return res.data

--- a/apps/platform/lib/api/instance.ts
+++ b/apps/platform/lib/api/instance.ts
@@ -17,10 +17,6 @@ axiosInstance.interceptors.request.use(
       config.headers.Authorization = `Bearer ${tokens.accessToken}`
     }
 
-    if (tokens?.refreshToken) {
-      config.headers['x-refresh-token'] = tokens.refreshToken
-    }
-
     return config
   },
   (error) => {

--- a/apps/platform/lib/api/instance.ts
+++ b/apps/platform/lib/api/instance.ts
@@ -1,15 +1,56 @@
 import axios from 'axios'
+import {
+  clearStoredAuthTokens,
+  getStoredAuthTokens,
+  setStoredAuthTokens,
+} from '@lib/auth/token-storage'
 
 export const axiosInstance = axios.create({
   baseURL: 'https://apidalla.snkres.com',
-  withCredentials: true,
 })
 
 axiosInstance.interceptors.request.use(
   async (config) => {
+    const tokens = getStoredAuthTokens()
+
+    if (tokens?.accessToken) {
+      config.headers.Authorization = `Bearer ${tokens.accessToken}`
+    }
+
+    if (tokens?.refreshToken) {
+      config.headers['x-refresh-token'] = tokens.refreshToken
+    }
+
     return config
   },
   (error) => {
+    return Promise.reject(error)
+  },
+)
+
+axiosInstance.interceptors.response.use(
+  (response) => {
+    const accessToken = response.headers['x-access-token']
+    const refreshToken = response.headers['x-refresh-token']
+
+    if (accessToken && refreshToken) {
+      setStoredAuthTokens({ accessToken, refreshToken })
+    }
+
+    return response
+  },
+  (error) => {
+    if (axios.isAxiosError(error) && error.response) {
+      error.status = error.response.status
+
+      if (
+        error.response.status === 401 &&
+        !String(error.config?.url || '').startsWith('/auth/')
+      ) {
+        clearStoredAuthTokens()
+      }
+    }
+
     return Promise.reject(error)
   },
 )

--- a/apps/platform/lib/auth/token-storage.ts
+++ b/apps/platform/lib/auth/token-storage.ts
@@ -7,6 +7,7 @@ export interface AuthTokens {
 
 const AUTH_STORAGE_KEY = 'dalla:auth'
 export const AUTH_TOKENS_CHANGED_EVENT = 'dalla:auth-tokens-changed'
+const AUTH_SESSION_COOKIE = 'dalla_session'
 
 function isBrowser() {
   return typeof window !== 'undefined'
@@ -66,6 +67,9 @@ export function setStoredAuthTokens(tokens: {
     JSON.stringify({ accessToken, refreshToken }),
   )
 
+  const secure = window.location.protocol === 'https:' ? '; Secure' : ''
+  document.cookie = `${AUTH_SESSION_COOKIE}=1; path=/; SameSite=Lax${secure}`
+
   dispatchAuthTokensChanged()
 }
 
@@ -73,5 +77,7 @@ export function clearStoredAuthTokens() {
   if (!isBrowser()) return
 
   window.localStorage.removeItem(AUTH_STORAGE_KEY)
+  const secure = window.location.protocol === 'https:' ? '; Secure' : ''
+  document.cookie = `${AUTH_SESSION_COOKIE}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax${secure}`
   dispatchAuthTokensChanged()
 }

--- a/apps/platform/lib/auth/token-storage.ts
+++ b/apps/platform/lib/auth/token-storage.ts
@@ -1,0 +1,77 @@
+'use client'
+
+export interface AuthTokens {
+  accessToken: string
+  refreshToken: string
+}
+
+const AUTH_STORAGE_KEY = 'dalla:auth'
+export const AUTH_TOKENS_CHANGED_EVENT = 'dalla:auth-tokens-changed'
+
+function isBrowser() {
+  return typeof window !== 'undefined'
+}
+
+function dispatchAuthTokensChanged() {
+  if (!isBrowser()) return
+
+  window.dispatchEvent(new CustomEvent(AUTH_TOKENS_CHANGED_EVENT))
+}
+
+export function getStoredAuthTokens(): AuthTokens | null {
+  if (!isBrowser()) return null
+
+  const rawValue = window.localStorage.getItem(AUTH_STORAGE_KEY)
+  if (!rawValue) return null
+
+  try {
+    const parsed = JSON.parse(rawValue) as Partial<AuthTokens>
+
+    if (!parsed.accessToken || !parsed.refreshToken) {
+      window.localStorage.removeItem(AUTH_STORAGE_KEY)
+      return null
+    }
+
+    return {
+      accessToken: parsed.accessToken,
+      refreshToken: parsed.refreshToken,
+    }
+  } catch {
+    window.localStorage.removeItem(AUTH_STORAGE_KEY)
+    return null
+  }
+}
+
+export function hasStoredAccessToken() {
+  return Boolean(getStoredAuthTokens()?.accessToken)
+}
+
+export function setStoredAuthTokens(tokens: {
+  accessToken?: string
+  refreshToken?: string
+  access_token?: string
+  refresh_token?: string
+}) {
+  if (!isBrowser()) return
+
+  const accessToken = tokens.accessToken ?? tokens.access_token
+  const refreshToken = tokens.refreshToken ?? tokens.refresh_token
+
+  if (!accessToken || !refreshToken) {
+    return
+  }
+
+  window.localStorage.setItem(
+    AUTH_STORAGE_KEY,
+    JSON.stringify({ accessToken, refreshToken }),
+  )
+
+  dispatchAuthTokensChanged()
+}
+
+export function clearStoredAuthTokens() {
+  if (!isBrowser()) return
+
+  window.localStorage.removeItem(AUTH_STORAGE_KEY)
+  dispatchAuthTokensChanged()
+}

--- a/apps/platform/lib/hooks/use-sso.tsx
+++ b/apps/platform/lib/hooks/use-sso.tsx
@@ -6,6 +6,7 @@ import { loginWithGoogle, loginWithLinkedIn } from '@lib/api/auth/login'
 import { LinkedInProfile } from '@lib/api/auth/linkedin'
 import { useSearchParams } from 'next/navigation'
 import { useTransitionRouter } from 'next-view-transitions'
+import { setStoredAuthTokens } from '@lib/auth/token-storage'
 
 const GOOGLE_CLIENT_ID =
   '633251838183-s9eaujn7vg0iv32ovdbg4fql9a5i2o50.apps.googleusercontent.com'
@@ -128,6 +129,7 @@ export function useSSO({ mode }: { mode: 'company' | 'user' }) {
             .then((result) => {
               console.log('Google login result:', result)
               if (result.success) {
+                setStoredAuthTokens(result.data)
                 router.push('/')
               } else {
                 toast({
@@ -323,6 +325,7 @@ export function useSSO({ mode }: { mode: 'company' | 'user' }) {
             console.log('Google login result:', result)
 
             if (result.success) {
+              setStoredAuthTokens(result.data)
               window.location.href = '/'
             } else {
               toast({
@@ -346,6 +349,7 @@ export function useSSO({ mode }: { mode: 'company' | 'user' }) {
             console.log('Google login result:', result)
 
             if (result.success) {
+              setStoredAuthTokens(result.data)
               window.location.href = '/'
             } else {
               toast({
@@ -439,6 +443,7 @@ export function useSSO({ mode }: { mode: 'company' | 'user' }) {
           })
 
           if (result.success) {
+            setStoredAuthTokens(result.data)
             // Clean up session storage
             sessionStorage.removeItem('linkedin_auth_state')
             sessionStorage.removeItem('linkedin_user_type')

--- a/apps/platform/middleware.ts
+++ b/apps/platform/middleware.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const AUTH_SESSION_COOKIE = 'dalla_session'
+
+const PUBLIC_PATHS = [
+  '/login',
+  '/signup',
+  '/forgot-password',
+  '/reset-password',
+  '/verify',
+  '/onboard',
+]
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  const isPublicPath = PUBLIC_PATHS.some(
+    (path) => pathname === path || pathname.startsWith(`${path}/`),
+  )
+
+  if (isPublicPath) {
+    return NextResponse.next()
+  }
+
+  const sessionCookie = request.cookies.get(AUTH_SESSION_COOKIE)
+
+  if (!sessionCookie?.value) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  return NextResponse.next()
+}
+
+// Match all routes except Next.js internals and static files
+const MIDDLEWARE_MATCHER =
+  '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'
+
+export const config = {
+  matcher: [MIDDLEWARE_MATCHER],
+}


### PR DESCRIPTION
## Summary
- switch platform auth to localStorage-backed access and refresh tokens
- replace cookie-based frontend route gating with client-side token guards
- wire axios to send auth headers and handle token refresh headers from the API

## Testing
- pnpm --dir apps/platform type-check